### PR TITLE
fix update problem

### DIFF
--- a/dialect/sql/sqlgraph/graph.go
+++ b/dialect/sql/sqlgraph/graph.go
@@ -652,6 +652,9 @@ func (u *updater) nodes(ctx context.Context, tx dialect.ExecQuerier) (int, error
 	)
 	selector := u.builder.Select(u.Node.ID.Column).
 		From(u.builder.Table(u.Node.Table))
+
+	archivedWherePredicate := selector.Clone().P()
+
 	if pred := u.Predicate; pred != nil {
 		pred(selector)
 	}
@@ -670,7 +673,7 @@ func (u *updater) nodes(ctx context.Context, tx dialect.ExecQuerier) (int, error
 	if len(ids) == 0 {
 		return 0, nil
 	}
-	update := u.builder.Update(u.Node.Table).Where(selector.Clone().P())
+	update := u.builder.Update(u.Node.Table).Where(archivedWherePredicate)
 	if err := u.setTableColumns(update, addEdges, clearEdges); err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
下面的`updater.Predicate(selector)`会导致`selector.P()`改变，导致update where xxx的xxx出问题。

测试后，有了这个改动，query就正常了。

*我不确定`updater.Predicate`是干什么的。