### PR TITLE
fix update predicate problem

### DIFF
--- a/dialect/sql/builder.go
+++ b/dialect/sql/builder.go
@@ -761,6 +761,38 @@ func (u *UpdateBuilder) Query() (string, []interface{}) {
 	return u.String(), u.args
 }
 
+func (u *UpdateBuilder) QueryWithSelectPredicate() (string, []interface{}) {
+	u.WriteString("UPDATE ")
+	u.Ident(u.table).Pad().WriteString("SET ")
+	for i, c := range u.nulls {
+		if i > 0 {
+			u.Comma()
+		}
+		u.Ident(c).WriteString(" = NULL")
+	}
+	if len(u.nulls) > 0 && len(u.columns) > 0 {
+		u.Comma()
+	}
+	for i, c := range u.columns {
+		if i > 0 {
+			u.Comma()
+		}
+		u.Ident(c).WriteString(" = ")
+		switch v := u.values[i].(type) {
+		case Querier:
+			u.Join(v)
+		default:
+			u.Arg(v)
+		}
+	}
+	if u.where != nil {
+		u.WriteString(" WHERE ")
+		u.WriteString(u.where.String())
+		u.args = append(u.args, u.where.args...)
+	}
+	return u.String(), u.args
+}
+
 // DeleteBuilder is a builder for `DELETE` statement.
 type DeleteBuilder struct {
 	Builder

--- a/dialect/sql/sqlgraph/graph.go
+++ b/dialect/sql/sqlgraph/graph.go
@@ -672,7 +672,7 @@ func (u *updater) nodes(ctx context.Context, tx dialect.ExecQuerier) (int, error
 		return 0, nil
 	}
 	// update := u.builder.Update(u.Node.Table).Where(matchID(u.Node.ID.Column, ids))
-	update := u.builder.Update(u.Node.Table).Where(selector.P())
+	update := u.builder.Update(u.Node.Table).Where(selector.Clone().P())
 	if err := u.setTableColumns(update, addEdges, clearEdges); err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
升级后发现update的where predicate有问题。

之前的解决方法把`where...`搞没了，不能那么弄。

发现之前predicate是给select query用的，可能怎么处理过了。再给update query用的时候，会被recursive的重复解析。想到的解决方法是，对这种select query出来的predicate，直接取值，不让他解析。