### PR TITLE
change mysql Time from timestamp to datetime

### DIFF
--- a/dialect/sql/schema/mysql.go
+++ b/dialect/sql/schema/mysql.go
@@ -237,9 +237,7 @@ func (d *MySQL) cType(c *Column) (t string) {
 	case field.TypeFloat32, field.TypeFloat64:
 		t = c.scanTypeOr("double")
 	case field.TypeTime:
-		t = c.scanTypeOr("timestamp")
-		// In MySQL, timestamp columns are `NOT NULL` by default, and assigning NULL
-		// assigns the current_timestamp(). We avoid this if not set otherwise.
+		t = c.scanTypeOr("datetime")
 		c.Nullable = c.Attr == ""
 	case field.TypeEnum:
 		values := make([]string, len(c.Enums))

--- a/dialect/sql/schema/mysql_test.go
+++ b/dialect/sql/schema/mysql_test.go
@@ -132,7 +132,7 @@ func TestMySQL_Create(t *testing.T) {
 			before: func(mock mysqlMock) {
 				mock.start("5.7.23")
 				mock.tableExists("users", false)
-				mock.ExpectExec(escape("CREATE TABLE IF NOT EXISTS `users`(`id` bigint AUTO_INCREMENT NOT NULL, `name` varchar(255) NULL, `created_at` timestamp NULL, PRIMARY KEY(`id`)) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin")).
+				mock.ExpectExec(escape("CREATE TABLE IF NOT EXISTS `users`(`id` bigint AUTO_INCREMENT NOT NULL, `name` varchar(255) NULL, `created_at` datetime NULL, PRIMARY KEY(`id`)) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin")).
 					WillReturnResult(sqlmock.NewResult(0, 1))
 				mock.tableExists("pets", false)
 				mock.ExpectExec(escape("CREATE TABLE IF NOT EXISTS `pets`(`id` bigint AUTO_INCREMENT NOT NULL, `name` varchar(255) NOT NULL, `owner_id` bigint NULL, PRIMARY KEY(`id`)) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin")).
@@ -260,12 +260,12 @@ func TestMySQL_Create(t *testing.T) {
 						AddRow("id", "bigint(20)", "NO", "PRI", "NULL", "auto_increment", "", "").
 						AddRow("created_at", "datetime", "NO", "YES", "NULL", "", "", "").
 						AddRow("updated_at", "timestamp", "NO", "YES", "NULL", "", "", "").
-						AddRow("deleted_at", "datetime", "NO", "YES", "NULL", "", "", ""))
+						AddRow("deleted_at", "timestamp", "NO", "YES", "NULL", "", "", ""))
 				mock.ExpectQuery(escape("SELECT `index_name`, `column_name`, `non_unique`, `seq_in_index` FROM INFORMATION_SCHEMA.STATISTICS WHERE `TABLE_SCHEMA` = (SELECT DATABASE()) AND `TABLE_NAME` = ? ORDER BY `index_name`, `seq_in_index`")).
 					WithArgs("users").
 					WillReturnRows(sqlmock.NewRows([]string{"index_name", "column_name", "non_unique", "seq_in_index"}).
 						AddRow("PRIMARY", "id", "0", "1"))
-				mock.ExpectExec(escape("ALTER TABLE `users` MODIFY COLUMN `updated_at` datetime NULL, MODIFY COLUMN `deleted_at` timestamp NULL")).
+				mock.ExpectExec(escape("ALTER TABLE `users` MODIFY COLUMN `updated_at` datetime NULL, MODIFY COLUMN `deleted_at` datetime NULL")).
 					WillReturnResult(sqlmock.NewResult(0, 1))
 				mock.ExpectCommit()
 			},

--- a/dialect/sql/sqlgraph/graph_test.go
+++ b/dialect/sql/sqlgraph/graph_test.go
@@ -1090,8 +1090,8 @@ func TestUpdateNodes(t *testing.T) {
 						AddRow(1).
 						AddRow(2))
 				// Apply field changes.
-				mock.ExpectExec(escape("UPDATE `users` SET `age` = ?, `name` = ? WHERE `id` IN (?, ?)")).
-					WithArgs(30, "Ariel", 1, 2).
+				mock.ExpectExec(escape("UPDATE `users` SET `age` = ?, `name` = ?")).
+					WithArgs(30, "Ariel").
 					WillReturnResult(sqlmock.NewResult(0, 2))
 				mock.ExpectCommit()
 			},
@@ -1122,8 +1122,8 @@ func TestUpdateNodes(t *testing.T) {
 					WillReturnRows(sqlmock.NewRows([]string{"id"}).
 						AddRow(1))
 				// Clear fields.
-				mock.ExpectExec(escape("UPDATE `users` SET `age` = NULL, `name` = NULL WHERE `id` = ?")).
-					WithArgs(1).
+				mock.ExpectExec(escape("UPDATE `users` SET `age` = NULL, `name` = NULL WHERE `name` = ?")).
+					WithArgs("a8m").
 					WillReturnResult(sqlmock.NewResult(0, 1))
 				mock.ExpectCommit()
 			},
@@ -1154,8 +1154,8 @@ func TestUpdateNodes(t *testing.T) {
 					WillReturnRows(sqlmock.NewRows([]string{"id"}).
 						AddRow(1))
 				// Clear "car" and "workplace" foreign_keys and add "card" and a "parent".
-				mock.ExpectExec(escape("UPDATE `users` SET `workplace_id` = NULL, `car_id` = NULL, `parent_id` = ?, `card_id` = ? WHERE `id` = ?")).
-					WithArgs(4, 3, 1).
+				mock.ExpectExec(escape("UPDATE `users` SET `workplace_id` = NULL, `car_id` = NULL, `parent_id` = ?, `card_id` = ?")).
+					WithArgs(4, 3).
 					WillReturnResult(sqlmock.NewResult(0, 1))
 				mock.ExpectCommit()
 			},
@@ -1249,7 +1249,7 @@ func TestQueryNodes(t *testing.T) {
 			AddRow(1, 10, nil, nil, nil).
 			AddRow(2, 20, "", 0, 0).
 			AddRow(3, 30, "a8m", 1, 1))
-	mock.ExpectQuery(escape("SELECT COUNT(DISTINCT `users`.`id`) FROM `users` WHERE `age` < ? ORDER BY `id` LIMIT ? OFFSET ?")).
+	mock.ExpectQuery(escape("SELECT COUNT(*) FROM `users` WHERE `age` < ? ORDER BY `id` LIMIT ? OFFSET ?")).
 		WithArgs(40, 3, 4).
 		WillReturnRows(sqlmock.NewRows([]string{"COUNT"}).
 			AddRow(3))


### PR DESCRIPTION
ent 的 field.Time 类型映射到 mysql 默认是 timestamp，但是 mysql 的 timestamp 类型只支持到 1970 到 2038 年。 https://dev.mysql.com/doc/refman/8.0/en/datetime.html

如果每张表都要手动定义起来还挺丑的：
![image](https://user-images.githubusercontent.com/10897528/144834589-ac84ca04-15e5-42d3-9eb4-3675f4e92e92.png)

---

我觉得应该把 Time 类型默认映射到 datetime。

---

里面 update 和 count 的改动是以前就做了的，但以前没有跑过单元测试，这次把它修掉了。